### PR TITLE
Refactoring BackToTheFuture

### DIFF
--- a/src/main/scala/mesosphere/mesos/util/FrameworkIdUtil.scala
+++ b/src/main/scala/mesosphere/mesos/util/FrameworkIdUtil.scala
@@ -8,6 +8,7 @@ import java.util.logging.{Level, Logger}
 import scala.util.{Failure, Success}
 import scala.concurrent.{Future, Await, ExecutionContext}
 import scala.concurrent.duration.Duration
+import mesosphere.util.BackToTheFuture.BackToTheFutureTimeout
 
 /**
  * Utility class for keeping track of a framework ID in Mesos state.
@@ -23,7 +24,8 @@ class FrameworkIdUtil(val state: State, val key: String = "frameworkId") {
 
   import BackToTheFuture.futureToFutureOption
 
-  def fetch(wait: Duration = defaultWait)(implicit ec: ExecutionContext): Option[FrameworkIDProto] = {
+  def fetch(wait: Duration = defaultWait)
+           (implicit ec: ExecutionContext, timeout: BackToTheFutureTimeout): Option[FrameworkIDProto] = {
     val f: Future[Option[FrameworkIDProto]] = state.fetch(key).map {
       case Some(variable) if variable.value().length > 0 => {
         try {
@@ -41,7 +43,8 @@ class FrameworkIdUtil(val state: State, val key: String = "frameworkId") {
     Await.result(f, wait)
   }
 
-  def store(frameworkId: FrameworkIDProto)(implicit ec: ExecutionContext) {
+  def store(frameworkId: FrameworkIDProto)
+           (implicit ec: ExecutionContext, timeout: BackToTheFutureTimeout) {
     state.fetch(key).map {
       case Some(oldVariable) => {
         val newVariable = oldVariable.mutate(frameworkId.toByteArray)
@@ -58,7 +61,8 @@ class FrameworkIdUtil(val state: State, val key: String = "frameworkId") {
     }
   }
 
-  def setIdIfExists(frameworkInfo: FrameworkInfoProto.Builder)(implicit ec: ExecutionContext) {
+  def setIdIfExists(frameworkInfo: FrameworkInfoProto.Builder)
+                   (implicit ec: ExecutionContext, timeout: BackToTheFutureTimeout) {
     fetch() match {
       case Some(id) => {
         log.info("Setting framework ID to %s".format(id.getValue))

--- a/src/main/scala/mesosphere/util/BackToTheFuture.scala
+++ b/src/main/scala/mesosphere/util/BackToTheFuture.scala
@@ -1,34 +1,44 @@
 package mesosphere.util
 
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.{Future => JFuture}
+import language.postfixOps
+import java.util.concurrent.{Future => JFuture, TimeUnit, ExecutionException}
 import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.duration._
 
 
 object BackToTheFuture {
 
+  case class BackToTheFutureTimeout(d: Duration)
 
-  implicit def futureToFutureOption[T](f: JFuture[T])(implicit ec: ExecutionContext): Future[Option[T]] = {
+  // To use this default timeout, please "import  mesosphere.util.BackToTheFuture.Implicits._"
+  object Implicits {
+    implicit val default_timeout = BackToTheFutureTimeout(2 seconds)
+  }
+
+  implicit def futureToFutureOption[T](f: JFuture[T])
+                                      (implicit ec: ExecutionContext, timeout: BackToTheFutureTimeout): Future[Option[T]] = {
     Future {
       try {
-        Option(f.get)
+        Option(f.get(timeout.d.toMicros, TimeUnit.MICROSECONDS))
       } catch {
         case e: ExecutionException => throw e.getCause
       }
     }
   }
 
-  implicit def futureToFuture[T](f: JFuture[T])(implicit ec: ExecutionContext): Future[T] = {
+  implicit def futureToFuture[T](f: JFuture[T])
+                                (implicit ec: ExecutionContext, timeout: BackToTheFutureTimeout): Future[T] = {
     Future {
       try {
-        f.get
+        f.get(timeout.d.toMicros, TimeUnit.MICROSECONDS)
       } catch {
         case e: ExecutionException => throw e.getCause
       }
     }
   }
 
-  implicit def valueToFuture[T](value: T)(implicit ec: ExecutionContext): Future[T] = {
+  implicit def valueToFuture[T](value: T)
+                               (implicit ec: ExecutionContext, to: BackToTheFutureTimeout): Future[T] = {
     Future {
       value
     }


### PR DESCRIPTION
Hello committers.
This pull request contains two things about refactoring `BackToTheFuture`.
#### Eliminated `ExecutionContext.Implicits.global`

`ExecutionContext.Implicits.global` is good for normal use case.  But I think it is not good for async library.

It's because  `global` execution context is concrete implementation and has its characteristics in parallelism.  This tries to keep the CPU(cores) busy. Therefore this leads to limit parallelism.  I think async libraries shouldn't force users to obey this specific parallel execution semantics.

Please refer to my [gist](https://gist.github.com/everpeace/8630941f4c4e8f8a47ac) for detail.  I wrote sample program to show the difference between execution contexts.
#### Changed to use `JFuture.get(timeout, timeunit)` instead of `JFuture.get()`

`java.util.concurrent.Future.get()` doesn't guarantee to stop.  This can possibly block forever. Returned future itself can be timed out with `Await.result()`.  However, this doesn't stop/interrupt `get()` thread. Consequently, this thread will probably leak. Particularly, If the future returned by `org.apache.mesos.ZookeeperState`, this blocks forever in `get()` method when Zookeeper is dead.

To control timeout amount, I introduced `BackToTheFutureTimout` case class.  To specify timeout, Please inject implicit `BackToTheFutureTimeout` value, or `import mesosphere.util.BackToTheFuture.Implicits._`.
