### PR TITLE
Updated to Mesos 0.21.0

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -17,7 +17,7 @@ object MesosUtilsBuild extends Build {
 
   lazy val baseSettings = Defaults.defaultSettings ++ Seq (
     organization := "mesosphere",
-    crossScalaVersions := Seq("2.10.4", "2.11.2"),
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
     scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
     javacOptions in Compile ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
     resolvers ++= Seq(
@@ -69,7 +69,7 @@ object Dependencies {
 object Dependency {
   object V {
     // runtime deps versions
-    val Mesos = "0.20.1"
+    val Mesos = "0.21.0"
 
     // test deps versions
     val ScalaTest = "2.2.1"

--- a/src/main/scala/mesosphere/mesos/protos/Implicits.scala
+++ b/src/main/scala/mesosphere/mesos/protos/Implicits.scala
@@ -163,6 +163,7 @@ object Implicits {
       case TaskRunning  => Protos.TaskState.TASK_RUNNING
       case TaskStaging  => Protos.TaskState.TASK_STAGING
       case TaskStarting => Protos.TaskState.TASK_STARTING
+      case TaskError    => Protos.TaskState.TASK_ERROR
     }
   }
 
@@ -175,6 +176,7 @@ object Implicits {
       case Protos.TaskState.TASK_RUNNING  => TaskRunning
       case Protos.TaskState.TASK_STAGING  => TaskStaging
       case Protos.TaskState.TASK_STARTING => TaskStarting
+      case Protos.TaskState.TASK_ERROR    => TaskError
     }
   }
 

--- a/src/main/scala/mesosphere/mesos/protos/TaskState.scala
+++ b/src/main/scala/mesosphere/mesos/protos/TaskState.scala
@@ -8,3 +8,4 @@ object TaskFinished extends TaskState
 object TaskFailed extends TaskState
 object TaskKilled extends TaskState
 object TaskLost extends TaskState
+object TaskError extends TaskState


### PR DESCRIPTION
Updated Mesos version to 0.21.0.
Updated cross version of 2.11 to 2.11.4.
Updated TaskState handling to catch TASK_ERROR, introduced in Mesos 0.21.0.
